### PR TITLE
Support iOS IPA files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,9 @@ jobs:
           wolfia-api-key-secret: ${{ secrets.WOLFIA_API_KEY_SECRET }}
           track-id: ${{ vars.TRACK_ID }}
           app-path: data/hacker.apk
+
+          ### For iOS ###
+          # app-connect-api-key-id: ${{ vars.APP_CONNECT_API_KEY_ID }}
+          # app-connect-api-issuer: ${{ vars.APP_CONNECT_API_ISSUER }}
+          # app-connect-secret-base64: ${{ secrets.APP_CONNECT_SECRET_BASE64 }}
+          # app-path: data/app.ipa

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.secrets
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -2,35 +2,60 @@
 
 This action allows you to upload a binary to [Wolfia](https://wolfia.com) for automating the distribution of your app.
 
-Refer [here](https://github.com/actions/wolfia-github-action/tree/releases/) for the previous version
+Refer [here](https://github.com/actions/wolfia-github-action/tree/releases/) for the previous version.
 
 ## Usage
 
-See [action.yml](action.yml). 
+See [action.yml](action.yml).
 
-| Key                   | Value                                                                                                                                                                               | Suggested Type | Required | Default |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|---------|
-| github-token          | Use github's automatically created [github token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-1-passing-the-github_token-as-an-input) | secret env     | true     | N/A     |
-| wolfia-api-key-id     | API Key ID for accessing the [Wolfia API](https://wolfia.com/docs/#generate-an-api-key)                                                                                             | vars           | true     | N/A     |
-| wolfia-api-key-secret | API Key Secret for accessing the [Wolfia API](https://wolfia.com/docs/#generate-an-api-key)                                                                                         | secret env     | true     | N/A     |
-| track-id              | Track ID for the app distribution that can be found on your Wolfia account                                                                                                          | vars           | true     | N/A     |
-| app-path              | Path to signed android/iOS file to be uploaded to Wolfia. Valid file extensions include **apk**, **app** (ipa support coming soon))                                                 | inline         | true     | N/A     |
+| Key                       | Value                                                                                                                                                                               | Suggested Type | Required | Default |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------- | ------- |
+| github-token              | Use GitHub's automatically created [github token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-1-passing-the-github_token-as-an-input) | secret env     | true     | N/A     |
+| wolfia-api-key-id         | API Key ID for accessing the [Wolfia API](https://wolfia.com/docs/#generate-an-api-key)                                                                                             | vars           | true     | N/A     |
+| wolfia-api-key-secret     | API Key Secret for accessing the [Wolfia API](https://wolfia.com/docs/#generate-an-api-key)                                                                                         | secret env     | true     | N/A     |
+| track-id                  | Track ID for the app distribution that can be found on your Wolfia account                                                                                                          | vars           | true     | N/A     |
+| app-path                  | Path to signed Android (**apk** or **aab**) or iOS (**ipa**) file to be uploaded to Wolfia.                                                                                         | inline         | true     | N/A     |
+| app-connect-api-key-id    | [App Connect API](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) Key ID                                                  | vars           | iOS-only | N/A     |
+| app-connect-api-issuer    | [App Connect API](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) Issuer                                                  | vars           | iOS-only | N/A     |
+| app-connect-secret-base64 | [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) private key file contents (base64 encoded)        | secret env     | iOS-only | N/A     |
 
-Here's an [example configuration](.github/workflows/build.yml).
+Here's an [example configuration](.github/workflows/test.yml).
 
-### Upload a binary to Wolfia
+### Upload an Android app binary to Wolfia
 
 ```yaml
 steps:
-- uses: wolfia-app/wolfia-github-action@v0.0.1
-  with:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    wolfia-api-key-id: ${{ vars.WOLFIA_API_KEY_ID }}
-    wolfia-api-key-secret: ${{ secrets.WOLFIA_API_KEY_SECRET }}
-    track-id: ${{ vars.TRACK_ID } }}
-    app-path: app/build/outputs/signed-app.apk
+  - uses: wolfia-app/wolfia-github-action@v0.0.1
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      wolfia-api-key-id: ${{ vars.WOLFIA_API_KEY_ID }}
+      wolfia-api-key-secret: ${{ secrets.WOLFIA_API_KEY_SECRET }}
+      track-id: ${{ vars.TRACK_ID } }}
+      app-path: app/build/outputs/signed-app.apk
+```
+
+### Upload an iOS app binary to Wolfia
+
+```yaml
+steps:
+  - uses: wolfia-app/wolfia-github-action@v0.0.1
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      wolfia-api-key-id: ${{ vars.WOLFIA_API_KEY_ID }}
+      wolfia-api-key-secret: ${{ secrets.WOLFIA_API_KEY_SECRET }}
+      track-id: ${{ vars.TRACK_ID } }}
+      app-path: app/build/outputs/signed-app.ipa
+      app-connect-api-key-id: ${{ vars.APP_CONNECT_API_KEY_ID }}
+      app-connect-api-issuer: ${{ vars.APP_CONNECT_API_ISSUER }}
+      app-connect-secret-base64: ${{ secrets.APP_CONNECT_SECRET_BASE64 }}
+```
+
+**Note**: to base64 encode the private key file and copy to your clipboard, run the following command:
+
+```bash
+base64 -i ~/AuthKey_XXXXXXXXXX.p8 | pbcopy
 ```
 
 ## License
 
-The scripts and documentation in this project are released under the [MIT License](LICENSE)
+The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: 'App Connect API Issuer'
     required: false # true for iOS
   app-connect-secret-base64:
-    description: 'App Connect API private key file contents (base64 encoded)''
+    description: 'App Connect API private key file contents (base64 encoded)'
     required: false # true for iOS
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,20 @@ inputs:
     description: 'API Key Secret for accessing the [Wolfia API](https://wolfia.com/docs/#generate-an-api-key).  Should be stored as a [github secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment).'
     required: true
   app-path:
-    description: 'The binary file path to upload to wolfia'
+    description: 'The binary file path to upload to Wolfia'
     required: true
   track-id:
     description: 'The track ID of the app you want to release. You can find the track ID in [Wolfia](https://wolfia.com/apps).'
     required: true
+  app-connect-api-key-id:
+    description: 'App Connect API Key ID'
+    required: false # true for iOS
+  app-connect-api-issuer:
+    description: 'App Connect API Issuer'
+    required: false # true for iOS
+  app-connect-secret-base64:
+    description: 'App Connect API private key file contents (base64 encoded)''
+    required: false # true for iOS
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
+        "@actions/exec": "^1.1.1",
         "@actions/github": "^5.1.1",
         "axios": "^1.2.4"
       },
@@ -37,6 +38,14 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "node_modules/@actions/github": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
@@ -55,6 +64,11 @@
       "dependencies": {
         "tunnel": "^0.0.6"
       }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
+      "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -6188,6 +6202,14 @@
         "uuid": "^8.3.2"
       }
     },
+    "@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "@actions/github": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
@@ -6206,6 +6228,11 @@
       "requires": {
         "tunnel": "^0.0.6"
       }
+    },
+    "@actions/io": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
+      "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
     "axios": "^1.2.4"
   },

--- a/src/wolfia.ts
+++ b/src/wolfia.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import * as fs from 'fs'
+import * as os from 'os'
 import FormData from 'form-data'
 import path from 'path'
 import type {AxiosResponse} from 'axios'
@@ -41,13 +42,25 @@ export async function uploadAppToWolfia(): Promise<AxiosResponse<string>> {
   formData.append('gitSha', gitSha)
 
   if (binaryPath.endsWith('.ipa')) {
-    // TODO: Handle App Store Connect API secret
     const appConnectApiKey = core.getInput('app-connect-api-key-id', {
       required: true
     })
     const appConnectApiIssuer = core.getInput('app-connect-api-issuer', {
       required: true
     })
+    const appConnectSecret = core.getInput('app-connect-secret', {
+      required: true
+    })
+    const appConnectSecretPath = path.join(
+      os.homedir(),
+      'private_keys',
+      `AuthKey_${appConnectApiKey}.p8`
+    )
+    fs.mkdirSync(path.dirname(appConnectSecretPath), {recursive: true})
+    fs.writeFileSync(
+      appConnectSecretPath,
+      Buffer.from(appConnectSecret, 'base64').toString('ascii')
+    )
 
     let output = ''
     let errorOutput = ''

--- a/src/wolfia.ts
+++ b/src/wolfia.ts
@@ -52,7 +52,7 @@ export async function uploadAppToWolfia(): Promise<AxiosResponse<string>> {
     let output = ''
     let errorOutput = ''
     const exitCode = await exec(
-      `xcrun altool --upload-app --type ios --file "${binaryPath}" --apiKey "${appConnectApiKey}" --apiIssuer "${appConnectApiIssuer} --output-format json`,
+      `xcrun altool --upload-app --type ios --file "${binaryPath}" --apiKey "${appConnectApiKey}" --apiIssuer "${appConnectApiIssuer}" --output-format json`,
       [],
       {
         listeners: {

--- a/src/wolfia.ts
+++ b/src/wolfia.ts
@@ -5,22 +5,32 @@ import path from 'path'
 import type {AxiosResponse} from 'axios'
 import axios from 'axios'
 import * as github from '@actions/github'
+import {exec} from '@actions/exec'
+
+const parseBuildId = (output: string): string | undefined =>
+  output.match(/Delivery UUID: ([a-z0-9-]+)/)?.[1]
 
 export async function uploadAppToWolfia(): Promise<AxiosResponse<string>> {
-  const apiKeyId = core.getInput('wolfia-api-key-id')
-  const apiKeySecret = core.getInput('wolfia-api-key-secret')
-  const trackId = core.getInput('track-id')
-  const binaryPath = core.getInput('app-path')
+  const apiKeyId = core.getInput('wolfia-api-key-id', {required: true})
+  const apiKeySecret = core.getInput('wolfia-api-key-secret', {required: true})
+  const trackId = core.getInput('track-id', {required: true})
+  const binaryPath = core.getInput('app-path', {required: true})
   const gitSha = github.context.sha
 
   if (!fs.existsSync(binaryPath)) {
     throw new Error(`App not found at ${binaryPath}`)
   }
-  if (!binaryPath.endsWith('.apk') && !binaryPath.endsWith('.aab')) {
+
+  if (
+    !binaryPath.endsWith('.apk') &&
+    !binaryPath.endsWith('.aab') &&
+    !binaryPath.endsWith('.ipa')
+  ) {
     throw new Error(
-      `App must be an apk or aab file. ipa files are not supported at this time. Path: ${binaryPath}`
+      `App must be an Android (.apk or .aab) or iOS (.ipa) file. Path: ${binaryPath}`
     )
   }
+
   const formData = new FormData()
   formData.append(
     'binary',
@@ -30,11 +40,59 @@ export async function uploadAppToWolfia(): Promise<AxiosResponse<string>> {
   formData.append('trackId', trackId)
   formData.append('gitSha', gitSha)
 
-  return axios.post('https://api.wolfia.com/upload/android', formData, {
-    headers: {
-      'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`,
-      'X-Api-Key-Id': apiKeyId,
-      'X-Api-Key-Secret': apiKeySecret
+  if (binaryPath.endsWith('.ipa')) {
+    // TODO: Handle App Store Connect API secret
+    const appConnectApiKey = core.getInput('app-connect-api-key-id', {
+      required: true
+    })
+    const appConnectApiIssuer = core.getInput('app-connect-api-issuer', {
+      required: true
+    })
+
+    let output = ''
+    let errorOutput = ''
+    const exitCode = await exec(
+      `xcrun altool --upload-app --type ios --file "${binaryPath}" --apiKey "${appConnectApiKey}" --apiIssuer "${appConnectApiIssuer} --output-format json`,
+      [],
+      {
+        listeners: {
+          stdout: (data: Buffer) => {
+            output += data.toString()
+          },
+          stderr: (data: Buffer) => {
+            errorOutput += data.toString()
+          }
+        }
+      }
+    )
+
+    if (exitCode !== 0) {
+      throw new Error(
+        `Failed to upload app to App Store Connect. Exit code: ${exitCode}. Output: ${output}. Error output: ${errorOutput}.`
+      )
     }
-  })
+
+    const buildId = parseBuildId(output)
+    if (!buildId) {
+      throw new Error(`Failed to parse build ID from output: ${output}.`)
+    }
+    formData.append('buildId', buildId)
+
+    // TODO: Upload build ID to Wolfia
+    return axios.post('https://api.wolfia.com/upload/ios', formData, {
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`,
+        'X-Api-Key-Id': apiKeyId,
+        'X-Api-Key-Secret': apiKeySecret
+      }
+    })
+  } else {
+    return axios.post('https://api.wolfia.com/upload/android', formData, {
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`,
+        'X-Api-Key-Id': apiKeyId,
+        'X-Api-Key-Secret': apiKeySecret
+      }
+    })
+  }
 }


### PR DESCRIPTION
This PR adds support for uploading iOS `IPA` files to the App Store Connect API and syncing with the Wolfia API:

- Update all existing inputs to be required as a runtime check since the action will fail without
- Support `ipa` file extension
- Support uploading an `ipa` file to App Store Connect
- Support syncing `ipa`, App Store Connect `buildId`, and other metadata to Wolfia
- Update docs